### PR TITLE
Create example Smokeping slave systemd unit

### DIFF
--- a/etc/systemd/system/smokeping-slave.service.example
+++ b/etc/systemd/system/smokeping-slave.service.example
@@ -1,0 +1,21 @@
+[Unit]
+Description=Smokeping slave service to connect to remote Smokeping master
+After=network.target
+After=systemd-user-sessions.service
+After=network-online.target
+
+[Service]
+User=smokeping
+ExecStart=/usr/bin/smokeping --master-url=https://your.site.url/smokeping.cgi --cache-dir=/var/smokeping/ --shared-secret=/var/smokeping/secret.txt --pid-dir /run
+ExecReload=/usr/bin/kill -HUP $MAINPID
+StandardError=syslog
+Type=forking
+PIDFile=/run/smokeping.pid
+TimeoutSec=30
+Restart=on-failure
+RestartSec=30
+StartLimitInterval=350
+StartLimitBurst=10
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Distribution package maintainers should customize username/paths as appropriate.
Should close https://github.com/oetiker/SmokePing/issues/44
Tested on Smokeping version 2.006000 / Arch linux
Some official distro package maintainers should review this once